### PR TITLE
adds example code to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,68 @@ This project contains the following clients:
 - [JavaScript](./clients/js/README.md)
 - [Rust](./clients/rust/README.md)
 
+## Getting started
+
+Install this library using the package manager of your choice.
+
+```sh shell
+npm install @tensor-foundation/whitelist
+```
+
+## Examples
+
+### Find Whitelist Account PDA
+
+```typescript
+const uuid = Buffer.from("099c4f20-fd22-44b3-af6d-43d2b9f4cf21".replaceAll("-", "")).toJSON().data;
+const whitelistSeeds: WhitelistSeeds = {
+    uuid: uuid
+}; 
+const [whitelistPDA] = await findWhitelistPda(whitelistSeeds); 
+```
+
+### Fetch Whitelist Account
+
+```typescript
+const transport = createDefaultRpcTransport({ url: "https://api.mainnet-beta.solana.com/" });
+const rpc = createSolanaRpc({ transport });
+const whitelistAccountResponse = await fetchWhitelist(rpc, whitelistPDA);
+```
+
+### Retrieve InitUpdateMintProof Instruction
+
+```typescript
+const mint = "DWBXzV8MjkCRLxWwZEZm6B3wfrpgh4oYcYKVxSuL9ay6" as Address<"MintType">;
+const whitelist = "ExGjYcjK1GNtQ5WnN3gy22132s6WMzrgFUHDNi6sT6nL" as Address<"WhitelistType">;
+const seeds = {mint: mint, whiltelist: whitelist};
+const mintProofPDA = await findMintProofPda(seeds);
+const URL = `https://api.mainnet.tensordev.io/api/v1/sdk/mint_proofs?whitelist=${whitelist}&mints=${mint}`;
+const response = await axios.get(
+    URL,
+    {
+        "headers": {
+            "x-tensor-api-key": API_KEY
+        }
+    }
+);
+const proof: Array<Uint8Array> = response.data[0].proof.map((proof) => proof.data);
+
+const initUpdateMintProofInput = {
+    whitelist: whitelist,
+    mint: mint,
+    mintProof: mintProofPDA,
+    user: wallet.publicKey,
+    proof: proof
+};
+const mintProofInstruction = getInitUpdateMintProofInstruction(initUpdateMintProofInput);
+```
+
+## Community and Support
+
+- **We're here to help!**
+
+- Join our developer community on [discord](https://discord.com/invite/6S3pRkfedB)
+
 ## Contributing
 
 Check out the [Contributing Guide](./CONTRIBUTING.md) the learn more about how to contribute to this project.


### PR DESCRIPTION
For this specific repo, we decided against an /examples folder, because of the low amount of actual example calls a normal dev would need for this SDK